### PR TITLE
Allow font to load when playing in HTTPs

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
 		<title>The Royal Wedding</title>
 
 		<link href="css/style.css" rel="stylesheet" type="text/css" />
-		<link href='http://fonts.googleapis.com/css?family=PT+Mono|Merienda|Droid+Sans+Mono&subset=latin,latin-ext' rel='stylesheet' type='text/css' />
+		<link href='https://fonts.googleapis.com/css?family=PT+Mono|Merienda|Droid+Sans+Mono&subset=latin,latin-ext' rel='stylesheet' type='text/css' />
 	</head>
 	<body>
 		<pre id="intro">

--- a/index.html
+++ b/index.html
@@ -72,8 +72,8 @@
     |                                           |      
     |                                           |      
     |                                           |      
-    |      <span>Created by <a href="http://ondras.zarovi.cz/">Ondřej Žára</a></span>               |      
-    |      <span>using <a href="http://ondras.github.com/rot.js/">rot.js</a></span>                         |      
+    |      <span>Created by <a href="https://ondras.zarovi.cz/">Ondřej Žára</a></span>               |      
+    |      <span>using <a href="https://ondras.github.com/rot.js/">rot.js</a></span>                         |      
     |      <span>forkable at <a href="https://github.com/ondras/trw">GitHub</a></span>                   |      
 ____|______________________________________     |      
 \                                          \    /      


### PR DESCRIPTION
Currently, when loading the fonts loading the game via https instead of http, the console outputs these errors:
- Firefox
> Blocked loading mixed active content “http://fonts.googleapis.com/css?family=PT+Mono|Merienda|Droid+Sans+Mono&subset=latin,latin-ext”
- Chrome
> Mixed Content: The page at 'https://ondras.github.io/trw/' was loaded over HTTPS, but requested an insecure stylesheet 'http://fonts.googleapis.com/css?family=PT+Mono|Merienda|Droid+Sans+Mono&subset=latin,latin-ext'. This request has been blocked; the content must be served over HTTPS.

The result is the browser falling back to a default serif font. This PR changes the href to the font by using https instead of http, so that either protocol can retrieve it.

This PR also updates the links to https as well
- To the personal site, since it redirects users to https already
- To the rot.js site; however, the rot.js site redirects users to a path `./hp`, which switches them back to http, so a comprehensive solution would also require a change in the rot.js repository