### PR TITLE
Update link to rot.js to use .io instead of .com

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
     |                                           |      
     |                                           |      
     |      <span>Created by <a href="https://ondras.zarovi.cz/">Ondřej Žára</a></span>               |      
-    |      <span>using <a href="https://ondras.github.com/rot.js/">rot.js</a></span>                         |      
+    |      <span>using <a href="https://ondras.github.io/rot.js/">rot.js</a></span>                         |      
     |      <span>forkable at <a href="https://github.com/ondras/trw">GitHub</a></span>                   |      
 ____|______________________________________     |      
 \                                          \    /      


### PR DESCRIPTION
One more URL change: this one fixes the link to rot.js because GitHub stopped supporting GH Pages domains that end in .com. Reference: https://github.blog/changelog/2021-01-29-github-pages-will-stop-redirecting-pages-sites-from-github-com-after-april-15-2021/
